### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ it('is negated', function () {
 ```
 
 ### Matchers
-Matchers performs boolean comparisions of actual and expected values.
+Matchers performs boolean comparisons of actual and expected values.
 Included matchers are:
 
 #### toBe


### PR DESCRIPTION
@neochrome, I've corrected a typographical error in the documentation of the [physalis](https://github.com/neochrome/physalis) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
